### PR TITLE
Add batch size to forward methods in VisionRetriever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env
 logs/
 data/
+outputs/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/vidore_benchmark/evaluation/evaluate.py
+++ b/src/vidore_benchmark/evaluation/evaluate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, List
 
 from datasets import Dataset
-from PIL import Image
+import torch
 
 from vidore_benchmark.retrievers.vision_retriever import VisionRetriever
 
@@ -39,9 +39,13 @@ def evaluate_dataset(
             raise ValueError("All queries are None")
 
     documents = ds[col_documents]
+    # Get the embeddings for the queries and documents - size (n_queries, emb_dim_query) and (n_documents, emb_dim_doc)
+    emb_queries, emb_documents = vision_retriever.get_embeddings(
+        queries, documents, batch_query=batch_query, batch_doc=batch_doc
+    )
 
     # Get the scores - size (n_queries, n_documents)
-    scores = vision_retriever.get_scores(queries, documents, batch_query=batch_query, batch_doc=batch_doc)
+    scores = vision_retriever.get_scores(emb_queries, emb_documents)
 
     # Get the relevant documents and results
     relevant_docs, results = vision_retriever.get_relevant_docs_results(ds, queries, scores)
@@ -55,10 +59,9 @@ def evaluate_dataset(
 def get_top_k(
     vision_retriever: VisionRetriever,
     queries: List[str],
-    documents: List[Image.Image] | List[str],
+    emb_queries: List[torch.Tensor],
+    emb_documents: List[torch.Tensor],
     file_names: List[str],
-    batch_query: int,
-    batch_doc: int,
     k: int,
 ) -> Dict[str, Dict[str, float]]:
     """
@@ -73,7 +76,7 @@ def get_top_k(
         ...
     }
     """
-    scores = vision_retriever.get_scores(queries, documents, batch_query=batch_query, batch_doc=batch_doc)
+    scores = vision_retriever.get_scores(emb_queries, emb_documents)
 
     passages2filename = {doc_idx: image_filename for doc_idx, image_filename in enumerate(file_names)}
 

--- a/src/vidore_benchmark/evaluation/evaluate.py
+++ b/src/vidore_benchmark/evaluation/evaluate.py
@@ -40,9 +40,8 @@ def evaluate_dataset(
 
     documents = ds[col_documents]
     # Get the embeddings for the queries and documents - size (n_queries, emb_dim_query) and (n_documents, emb_dim_doc)
-    emb_queries, emb_documents = vision_retriever.get_embeddings(
-        queries, documents, batch_query=batch_query, batch_doc=batch_doc
-    )
+    emb_queries = vision_retriever.forward_queries(queries, batch_size=batch_query)
+    emb_documents = vision_retriever.forward_documents(documents, batch_size=batch_doc)
 
     # Get the scores - size (n_queries, n_documents)
     scores = vision_retriever.get_scores(emb_queries, emb_documents)

--- a/src/vidore_benchmark/main.py
+++ b/src/vidore_benchmark/main.py
@@ -88,12 +88,11 @@ def retrieve_on_dataset(
     ds = cast(Dataset, load_dataset(dataset_name, split=split))
 
     # Get embeddings for the queries and documents
-    emb_queries, emb_documents = retriever.get_embeddings(
-        queries=[query],
-        documents=list(ds["image"]) if retriever.use_visual_embedding else list(ds["text_description"]),
-        batch_query=1,
-        batch_doc=batch_size,
+    emb_queries = retriever.forward_queries([query], batch_size=1)
+    emb_documents = retriever.forward_documents(
+        list(ds["image"]) if retriever.use_visual_embedding else list(ds["text_description"]), batch_size=batch_size
     )
+
     # Get the top-k documents
     top_k = get_top_k(
         retriever,
@@ -138,12 +137,8 @@ def retrieve_on_pdfs(
     ds = generate_dataset_from_img_folder(data_dirpath)
 
     # Get embeddings for the queries and documents
-    emb_queries, emb_documents = retriever.get_embeddings(
-        queries=[query],
-        documents=list(ds["image"]) if retriever.use_visual_embedding else list(ds["text_description"]),
-        batch_query=1,
-        batch_doc=batch_size,
-    )
+    emb_queries = retriever.forward_queries([query], batch_size=1)
+    emb_documents = retriever.forward_documents(list(ds["image"]), batch_size=batch_size)
     # Get the top-k documents
     top_k = get_top_k(
         retriever,

--- a/src/vidore_benchmark/main.py
+++ b/src/vidore_benchmark/main.py
@@ -87,14 +87,20 @@ def retrieve_on_dataset(
     # Load the dataset
     ds = cast(Dataset, load_dataset(dataset_name, split=split))
 
+    # Get embeddings for the queries and documents
+    emb_queries, emb_documents = retriever.get_embeddings(
+        queries=[query],
+        documents=list(ds["image"]) if retriever.use_visual_embedding else list(ds["text_description"]),
+        batch_query=1,
+        batch_doc=batch_size,
+    )
     # Get the top-k documents
     top_k = get_top_k(
         retriever,
         queries=[query],
-        documents=list(ds["image"]) if retriever.use_visual_embedding else list(ds["text_description"]),
+        emb_queries=emb_queries,
+        emb_documents=emb_documents,
         file_names=list(ds["image_filename"]),
-        batch_query=1,
-        batch_doc=batch_size,
         k=k,
     )
 
@@ -129,16 +135,22 @@ def retrieve_on_pdfs(
     print(f"Found {len(image_files)} images in the directory `{data_dirpath}`")
 
     # Generate a dataset using the images
-    dataset = generate_dataset_from_img_folder(data_dirpath)
+    ds = generate_dataset_from_img_folder(data_dirpath)
 
+    # Get embeddings for the queries and documents
+    emb_queries, emb_documents = retriever.get_embeddings(
+        queries=[query],
+        documents=list(ds["image"]) if retriever.use_visual_embedding else list(ds["text_description"]),
+        batch_query=1,
+        batch_doc=batch_size,
+    )
     # Get the top-k documents
     top_k = get_top_k(
         retriever,
         queries=[query],
-        documents=list(dataset["image"]),
-        file_names=list(dataset["image_filename"]),
-        batch_query=1,
-        batch_doc=batch_size,
+        emb_queries=emb_queries,
+        emb_documents=emb_documents,
+        file_names=list(ds["image_filename"]),
         k=k,
     )
 

--- a/src/vidore_benchmark/retrievers/bge_m3_retriever.py
+++ b/src/vidore_benchmark/retrievers/bge_m3_retriever.py
@@ -1,4 +1,5 @@
 from typing import List, cast
+import math
 
 import torch
 from FlagEmbedding import BGEM3FlagModel
@@ -25,7 +26,7 @@ class BGEM3Retriever(VisionRetriever):
 
     def forward_queries(self, queries, batch_size: int, **kwargs) -> List[torch.Tensor]:
         list_emb_queries: List[torch.Tensor] = []
-        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total=len(queries) // batch_size):
+        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total= math.ceil(len(queries) / batch_size)):
             query_batch = cast(List[str], query_batch)
             output = self.model.encode(query_batch, max_length=512)["dense_vecs"]
             query_embeddings = torch.tensor(output).to(self.device)
@@ -36,7 +37,7 @@ class BGEM3Retriever(VisionRetriever):
     def forward_documents(self, documents: List[str], batch_size: int, **kwargs) -> List[torch.Tensor]:
         list_emb_documents: List[torch.Tensor] = []
         for doc_batch in tqdm(
-            batched(documents, batch_size), desc="Document batch", total=len(documents) // batch_size
+            batched(documents, batch_size), desc="Document batch", total=math.ceil(len(documents) / batch_size)
         ):
             doc_batch = cast(List[str], doc_batch)
             output = self.model.encode(doc_batch)["dense_vecs"]

--- a/src/vidore_benchmark/retrievers/bm25_retriever.py
+++ b/src/vidore_benchmark/retrievers/bm25_retriever.py
@@ -22,10 +22,10 @@ class BM25Retriever(VisionRetriever):
     def use_visual_embedding(self) -> bool:
         return False
 
-    def forward_queries(self, queries, batch_size, **kwargs) -> List[torch.Tensor]:
+    def forward_queries(self, queries, batch_size: int, **kwargs) -> List[torch.Tensor]:
         raise NotImplementedError("BM25Retriever only need get_scores_bm25 method.")
 
-    def forward_documents(self, documents: List[str], batch_size, **kwargs) -> List[torch.Tensor]:
+    def forward_documents(self, documents: List[str], batch_size: int, **kwargs) -> List[torch.Tensor]:
         raise NotImplementedError("BM25Retriever only need get_scores_bm25 method.")
 
     def get_scores(

--- a/src/vidore_benchmark/retrievers/bm25_retriever.py
+++ b/src/vidore_benchmark/retrievers/bm25_retriever.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, cast
+from typing import Dict, List, cast, Tuple
 
 import numpy as np
 import torch
@@ -23,12 +23,30 @@ class BM25Retriever(VisionRetriever):
         return False
 
     def forward_queries(self, queries, **kwargs) -> torch.Tensor:
-        raise NotImplementedError("BM25Retriever only need get_scores method.")
+        raise NotImplementedError("BM25Retriever only need get_scores_bm25 method.")
 
     def forward_documents(self, documents: List[str], **kwargs) -> torch.Tensor:
-        raise NotImplementedError("BM25Retriever only need get_scores method.")
+        raise NotImplementedError("BM25Retriever only need get_scores_bm25 method.")
+
+    def get_embeddings(
+        self,
+        queries: List[str],
+        documents: List[Image.Image] | List[str],
+        batch_query: int,
+        batch_doc: int,
+        **kwargs,
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+        raise NotImplementedError("BM25Retriever only need get_scores_bm25 method.")
 
     def get_scores(
+        self,
+        list_emb_queries: List[torch.Tensor],
+        list_emb_documents: List[torch.Tensor],
+        **kwargs,
+    ) -> torch.Tensor:
+        raise NotImplementedError("BM25Retriever only need get_scores_bm25 method.")
+
+    def get_scores_bm25(
         self,
         queries: List[str],
         documents: List[Image.Image] | List[str],

--- a/src/vidore_benchmark/retrievers/bm25_retriever.py
+++ b/src/vidore_benchmark/retrievers/bm25_retriever.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, cast, Tuple
+from typing import Dict, List, cast
 
 import numpy as np
 import torch
@@ -22,20 +22,10 @@ class BM25Retriever(VisionRetriever):
     def use_visual_embedding(self) -> bool:
         return False
 
-    def forward_queries(self, queries, **kwargs) -> torch.Tensor:
+    def forward_queries(self, queries, batch_size, **kwargs) -> List[torch.Tensor]:
         raise NotImplementedError("BM25Retriever only need get_scores_bm25 method.")
 
-    def forward_documents(self, documents: List[str], **kwargs) -> torch.Tensor:
-        raise NotImplementedError("BM25Retriever only need get_scores_bm25 method.")
-
-    def get_embeddings(
-        self,
-        queries: List[str],
-        documents: List[Image.Image] | List[str],
-        batch_query: int,
-        batch_doc: int,
-        **kwargs,
-    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+    def forward_documents(self, documents: List[str], batch_size, **kwargs) -> List[torch.Tensor]:
         raise NotImplementedError("BM25Retriever only need get_scores_bm25 method.")
 
     def get_scores(

--- a/src/vidore_benchmark/retrievers/colpali_retriever.py
+++ b/src/vidore_benchmark/retrievers/colpali_retriever.py
@@ -77,7 +77,7 @@ class ColPaliRetriever(VisionRetriever):
         batch_query["attention_mask"] = batch_query["attention_mask"][..., self.processor.image_seq_length :]
         return batch_query
 
-    def forward_queries(self, queries: List[str], batch_size, **kwargs) -> List[torch.Tensor]:
+    def forward_queries(self, queries: List[str], batch_size: int, **kwargs) -> List[torch.Tensor]:
         dataloader = DataLoader(
             queries,
             batch_size=batch_size,
@@ -93,7 +93,7 @@ class ColPaliRetriever(VisionRetriever):
 
         return qs
 
-    def forward_documents(self, documents: List[Image.Image], batch_size, **kwargs) -> List[torch.Tensor]:
+    def forward_documents(self, documents: List[Image.Image], batch_size: int, **kwargs) -> List[torch.Tensor]:
         dataloader = DataLoader(
             documents,
             batch_size=batch_size,

--- a/src/vidore_benchmark/retrievers/dummy_retriever.py
+++ b/src/vidore_benchmark/retrievers/dummy_retriever.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Tuple
 
 import torch
 from PIL import Image
@@ -36,13 +36,23 @@ class DummyRetriever(VisionRetriever):
     def forward_documents(self, documents: List[Image.Image], **kwargs) -> torch.Tensor:
         return torch.randn(len(documents), self.emb_dim_doc)
 
-    def get_scores(
+    def get_embeddings(
         self,
         queries: List[str],
         documents: List[Image.Image] | List[str],
         batch_query: int,
         batch_doc: int,
         **kwargs,
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+
+        return (
+            [torch.randn(batch_query, self.emb_dim_query) for _ in range(len(queries) // batch_query)],
+            [torch.randn(batch_doc, self.emb_dim_doc) for _ in range(len(documents) // batch_doc)],
+        )
+
+    def get_scores(
+        self,
+        list_emb_queries: List[torch.Tensor],
+        list_emb_documents: List[torch.Tensor],
     ) -> torch.Tensor:
-        scores = torch.randn(len(queries), len(documents))
-        return scores
+        return torch.randn(len(list_emb_queries), len(list_emb_documents))

--- a/src/vidore_benchmark/retrievers/dummy_retriever.py
+++ b/src/vidore_benchmark/retrievers/dummy_retriever.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import List
 
 import torch
 from PIL import Image
+from torch import Tensor
 
 from vidore_benchmark.retrievers.utils.register_retriever import register_vision_retriever
 from vidore_benchmark.retrievers.vision_retriever import VisionRetriever
@@ -30,25 +31,11 @@ class DummyRetriever(VisionRetriever):
     def use_visual_embedding(self) -> bool:
         return True
 
-    def forward_queries(self, queries: List[str], **kwargs) -> torch.Tensor:
-        return torch.randn(len(queries), self.emb_dim_query)
+    def forward_queries(self, queries: List[str], batch_size: int, **kwargs) -> List[Tensor]:
+        return [torch.randn(batch_size, self.emb_dim_query) for _ in range(len(queries) // batch_size)]
 
-    def forward_documents(self, documents: List[Image.Image], **kwargs) -> torch.Tensor:
-        return torch.randn(len(documents), self.emb_dim_doc)
-
-    def get_embeddings(
-        self,
-        queries: List[str],
-        documents: List[Image.Image] | List[str],
-        batch_query: int,
-        batch_doc: int,
-        **kwargs,
-    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
-
-        return (
-            [torch.randn(batch_query, self.emb_dim_query) for _ in range(len(queries) // batch_query)],
-            [torch.randn(batch_doc, self.emb_dim_doc) for _ in range(len(documents) // batch_doc)],
-        )
+    def forward_documents(self, documents: List[Image.Image], batch_size: int, **kwargs) -> List[Tensor]:
+        return [torch.randn(batch_size, self.emb_dim_doc) for _ in range(len(documents) // batch_size)]
 
     def get_scores(
         self,

--- a/src/vidore_benchmark/retrievers/jina_clip_retriever.py
+++ b/src/vidore_benchmark/retrievers/jina_clip_retriever.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import List, cast
+import math
 
 import torch
 from PIL import Image
@@ -28,7 +29,7 @@ class JinaClipRetriever(VisionRetriever):
 
     def forward_queries(self, queries, batch_size: int, **kwargs) -> List[torch.Tensor]:
         list_emb_queries: List[torch.Tensor] = []
-        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total=len(queries) // batch_size):
+        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total=math.ceil(len(queries) / batch_size)):
             query_batch = cast(List[str], query_batch)
             output = self.model.encode_text(query_batch)
             query_embeddings = torch.tensor(output).to(self.device)
@@ -40,7 +41,7 @@ class JinaClipRetriever(VisionRetriever):
 
         list_emb_documents: List[torch.Tensor] = []
         for doc_batch in tqdm(
-            batched(documents, batch_size), desc="Document batch", total=len(documents) // batch_size
+            batched(documents, batch_size), desc="Document batch", total=math.ceil(len(documents) / batch_size)
         ):
             doc_batch = cast(List[Image.Image], doc_batch)
             output = self.model.encode_image(doc_batch)

--- a/src/vidore_benchmark/retrievers/jina_clip_retriever.py
+++ b/src/vidore_benchmark/retrievers/jina_clip_retriever.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, cast, Tuple
+from typing import List, cast
 
 import torch
 from PIL import Image
@@ -26,41 +26,27 @@ class JinaClipRetriever(VisionRetriever):
     def use_visual_embedding(self) -> bool:
         return True
 
-    def forward_queries(self, queries: List[str], **kwargs) -> torch.Tensor:
-        output = self.model.encode_text(queries)
-        return torch.tensor(output).to(self.device)
-
-    def forward_documents(self, documents: List[Image.Image], **kwargs) -> torch.Tensor:
-        output = self.model.encode_image(documents)
-        return torch.tensor(output).to(self.device)
-
-    def get_embeddings(
-        self,
-        queries: List[str],
-        documents: List[Image.Image] | List[str],
-        batch_query: int,
-        batch_doc: int,
-        **kwargs,
-    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
-
-        # Sanity check: `documents` must be a list of images
-        if documents and not all(isinstance(doc, Image.Image) for doc in documents):
-            raise ValueError("Documents must be a list of images")
-        documents = cast(List[Image.Image], documents)
-
+    def forward_queries(self, queries, batch_size: int, **kwargs) -> List[torch.Tensor]:
         list_emb_queries: List[torch.Tensor] = []
-        for query_batch in tqdm(batched(queries, batch_query), desc="Query batch", total=len(queries) // batch_query):
+        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total=len(queries) // batch_size):
             query_batch = cast(List[str], query_batch)
-            query_embeddings = self.forward_queries(query_batch)
+            output = self.model.encode_text(query_batch)
+            query_embeddings = torch.tensor(output).to(self.device)
             list_emb_queries.append(query_embeddings)
 
-        list_emb_documents: List[torch.Tensor] = []
-        for doc_batch in tqdm(batched(documents, batch_doc), desc="Document batch", total=len(documents) // batch_doc):
-            doc_batch = cast(List[Image.Image], doc_batch)
-            doc_embeddings = self.forward_documents(doc_batch)
-            list_emb_documents.append(doc_embeddings)
+        return list_emb_queries
 
-        return list_emb_queries, list_emb_documents
+    def forward_documents(self, documents, batch_size: int, **kwargs) -> List[torch.Tensor]:
+
+        list_emb_documents: List[torch.Tensor] = []
+        for doc_batch in tqdm(
+            batched(documents, batch_size), desc="Document batch", total=len(documents) // batch_size
+        ):
+            doc_batch = cast(List[Image.Image], doc_batch)
+            output = self.model.encode_image(doc_batch)
+            doc_embeddings = torch.tensor(output).to(self.device)
+            list_emb_documents.append(doc_embeddings)
+        return list_emb_documents
 
     def get_scores(
         self,

--- a/src/vidore_benchmark/retrievers/nomic_retriever.py
+++ b/src/vidore_benchmark/retrievers/nomic_retriever.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, cast, Tuple
+from typing import List, cast
 
 import torch
 import torch.nn.functional as F
@@ -43,26 +43,42 @@ class NomicVisionRetriever(VisionRetriever):
         input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
         return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(input_mask_expanded.sum(1), min=1e-9)
 
-    def forward_queries(self, queries: List[str], **kwargs) -> torch.Tensor:
-        query_texts = ["search_query: " + query for query in queries]
-        encoded_input = self.text_tokenizer(query_texts, padding=True, truncation=True, return_tensors="pt").to(
-            self.device
-        )
-        with torch.no_grad():
-            qs = self.text_model(**encoded_input)
-        qs = self._mean_pooling(qs, encoded_input["attention_mask"])  # type: ignore
-        qs = F.layer_norm(qs, normalized_shape=(qs.shape[1],))
-        qs = F.normalize(qs, p=2, dim=1)
+    def forward_queries(self, queries, batch_size: int, **kwargs) -> List[torch.Tensor]:
+        list_emb_queries: List[torch.Tensor] = []
+        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total=len(queries) // batch_size):
+            query_batch = cast(List[str], query_batch)
 
-        return torch.tensor(qs).to(self.device)
+            query_texts = ["search_query: " + query for query in query_batch]
+            encoded_input = self.text_tokenizer(query_texts, padding=True, truncation=True, return_tensors="pt").to(
+                self.device
+            )
+            with torch.no_grad():
+                qs = self.text_model(**encoded_input)
+            qs = self._mean_pooling(qs, encoded_input["attention_mask"])  # type: ignore
+            qs = F.layer_norm(qs, normalized_shape=(qs.shape[1],))
+            qs = F.normalize(qs, p=2, dim=1)
 
-    def forward_documents(self, documents: List[Image.Image], **kwargs) -> torch.Tensor:
-        vision_inputs = self.processor(documents, return_tensors="pt").to(self.device)
-        with torch.no_grad():
-            ps = self.model(**vision_inputs).last_hidden_state
-            ps = F.normalize(ps[:, 0], p=2, dim=1)
+            query_embeddings = torch.tensor(qs).to(self.device)
+            list_emb_queries.append(query_embeddings)
 
-        return torch.tensor(ps).to(self.device)
+        return list_emb_queries
+
+    def forward_documents(self, documents, batch_size: int, **kwargs) -> List[torch.Tensor]:
+        list_emb_documents: List[torch.Tensor] = []
+        for doc_batch in tqdm(
+            batched(documents, batch_size), desc="Document batch", total=len(documents) // batch_size
+        ):
+            doc_batch = cast(List[Image.Image], doc_batch)
+
+            vision_inputs = self.processor(doc_batch, return_tensors="pt").to(self.device)
+            with torch.no_grad():
+                ps = self.model(**vision_inputs).last_hidden_state
+                ps = F.normalize(ps[:, 0], p=2, dim=1)
+
+            doc_embeddings = torch.tensor(ps).to(self.device)
+            list_emb_documents.append(doc_embeddings)
+
+        return list_emb_documents
 
     def get_scores(
         self,
@@ -75,30 +91,3 @@ class NomicVisionRetriever(VisionRetriever):
         scores = torch.einsum("bd,cd->bc", emb_queries, emb_documents)
 
         return scores
-
-    def get_embeddings(
-        self,
-        queries: List[str],
-        documents: List[Image.Image] | List[str],
-        batch_query: int,
-        batch_doc: int,
-        **kwargs,
-    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
-        # Sanity check: `documents` must be a list of images
-        if documents and not all(isinstance(doc, Image.Image) for doc in documents):
-            raise ValueError("Documents must be a list of Pillow images")
-        documents = cast(List[Image.Image], documents)
-
-        list_emb_queries: List[torch.Tensor] = []
-        for query_batch in tqdm(batched(queries, batch_query), desc="Query batch", total=len(queries) // batch_query):
-            query_batch = cast(List[str], query_batch)
-            query_embeddings = self.forward_queries(query_batch)
-            list_emb_queries.append(query_embeddings)
-
-        list_emb_documents: List[torch.Tensor] = []
-        for doc_batch in tqdm(batched(documents, batch_doc), desc="Document batch", total=len(documents) // batch_doc):
-            doc_batch = cast(List[Image.Image], doc_batch)
-            doc_embeddings = self.forward_documents(doc_batch)
-            list_emb_documents.append(doc_embeddings)
-
-        return list_emb_queries, list_emb_documents

--- a/src/vidore_benchmark/retrievers/nomic_retriever.py
+++ b/src/vidore_benchmark/retrievers/nomic_retriever.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import List, cast
+import math
 
 import torch
 import torch.nn.functional as F
@@ -45,7 +46,7 @@ class NomicVisionRetriever(VisionRetriever):
 
     def forward_queries(self, queries, batch_size: int, **kwargs) -> List[torch.Tensor]:
         list_emb_queries: List[torch.Tensor] = []
-        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total=len(queries) // batch_size):
+        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total=math.ceil(len(queries) / batch_size)):
             query_batch = cast(List[str], query_batch)
 
             query_texts = ["search_query: " + query for query in query_batch]
@@ -66,7 +67,7 @@ class NomicVisionRetriever(VisionRetriever):
     def forward_documents(self, documents, batch_size: int, **kwargs) -> List[torch.Tensor]:
         list_emb_documents: List[torch.Tensor] = []
         for doc_batch in tqdm(
-            batched(documents, batch_size), desc="Document batch", total=len(documents) // batch_size
+            batched(documents, batch_size), desc="Document batch", total=math.ceil(len(documents) / batch_size)
         ):
             doc_batch = cast(List[Image.Image], doc_batch)
 

--- a/src/vidore_benchmark/retrievers/siglip_retriever.py
+++ b/src/vidore_benchmark/retrievers/siglip_retriever.py
@@ -4,6 +4,7 @@ import torch
 from PIL import Image
 from tqdm import tqdm
 from transformers import AutoModel, AutoProcessor
+import math
 
 from vidore_benchmark.retrievers.utils.register_retriever import register_vision_retriever
 from vidore_benchmark.retrievers.vision_retriever import VisionRetriever
@@ -27,7 +28,7 @@ class SigLIPRetriever(VisionRetriever):
     def forward_queries(self, queries, batch_size: int, **kwargs) -> List[torch.Tensor]:
 
         list_emb_queries: List[torch.Tensor] = []
-        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total=len(queries) // batch_size):
+        for query_batch in tqdm(batched(queries, batch_size), desc="Query batch", total=math.ceil(len(queries) / batch_size)):
             query_batch = cast(List[str], query_batch)
             inputs_queries = self.processor(
                 text=query_batch, return_tensors="pt", padding="max_length", truncation=True
@@ -41,7 +42,7 @@ class SigLIPRetriever(VisionRetriever):
 
         list_emb_documents: List[torch.Tensor] = []
         for doc_batch in tqdm(
-            batched(documents, batch_size), desc="Document batch", total=len(documents) // batch_size
+            batched(documents, batch_size), desc="Document batch", total=math.ceil(len(documents) / batch_size)
         ):
             doc_batch = cast(List[Image.Image], doc_batch)
             list_doc = [document.convert("RGB") for document in doc_batch if isinstance(document, Image.Image)]

--- a/src/vidore_benchmark/retrievers/vision_retriever.py
+++ b/src/vidore_benchmark/retrievers/vision_retriever.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Tuple
 import torch
 from datasets import Dataset
 from mteb.evaluation.evaluators import RetrievalEvaluator
-from PIL import Image
 
 
 class VisionRetriever(ABC):
@@ -28,7 +27,7 @@ class VisionRetriever(ABC):
         pass
 
     @abstractmethod
-    def forward_queries(self, queries: Any, **kwargs) -> torch.Tensor | List[torch.Tensor]:
+    def forward_queries(self, queries: Any, batch_size: int, **kwargs) -> List[torch.Tensor]:
         """
         Forward pass the processed queries.
 
@@ -39,7 +38,7 @@ class VisionRetriever(ABC):
         pass
 
     @abstractmethod
-    def forward_documents(self, documents: Any, **kwargs) -> torch.Tensor | List[torch.Tensor]:
+    def forward_documents(self, documents: Any, batch_size: int, **kwargs) -> List[torch.Tensor]:
         """
         Forward pass the processed documents (i.e. page images).
 
@@ -64,30 +63,6 @@ class VisionRetriever(ABC):
 
         Output:
         - scores: torch.Tensor (n_queries, n_documents)
-        """
-        pass
-
-    @abstractmethod
-    def get_embeddings(
-        self,
-        queries: List[str],
-        documents: List[Image.Image] | List[str],
-        batch_query: int,
-        batch_doc: int,
-        **kwargs,
-    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
-        """
-        Get the embeddings for the queries and documents.
-
-        Inputs:
-        - queries: List[str]
-        - documents: List[Image.Image] | List[str]
-        - batch_query: int
-        - batch_doc: int
-
-        Outputs:
-        - emb_queries: List[torch.Tensor] (n_queries, emb_dim_query)
-        - emb_documents: List[torch.Tensor] (n_documents, emb_dim_doc)
         """
         pass
 

--- a/src/vidore_benchmark/retrievers/vision_retriever.py
+++ b/src/vidore_benchmark/retrievers/vision_retriever.py
@@ -52,19 +52,42 @@ class VisionRetriever(ABC):
     @abstractmethod
     def get_scores(
         self,
+        list_emb_queries: List[torch.Tensor],
+        list_emb_documents: List[torch.Tensor],
+    ) -> torch.Tensor:
+        """
+        Get the scores between queries and documents.
+
+        Inputs:
+        - list_emb_queries: List[torch.Tensor] (n_queries, emb_dim_query)
+        - list_emb_documents: List[torch.Tensor] (n_documents, emb_dim_doc)
+
+        Output:
+        - scores: torch.Tensor (n_queries, n_documents)
+        """
+        pass
+
+    @abstractmethod
+    def get_embeddings(
+        self,
         queries: List[str],
         documents: List[Image.Image] | List[str],
         batch_query: int,
         batch_doc: int,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
         """
-        Get the similarity scores between queries and documents.
+        Get the embeddings for the queries and documents.
 
-        `documents` can be a list of:
-        - PIL images olist of image filenames
-        - filepaths (strings) of the images
-        - OCR-ed text (strings) of the images.
+        Inputs:
+        - queries: List[str]
+        - documents: List[Image.Image] | List[str]
+        - batch_query: int
+        - batch_doc: int
+
+        Outputs:
+        - emb_queries: List[torch.Tensor] (n_queries, emb_dim_query)
+        - emb_documents: List[torch.Tensor] (n_documents, emb_dim_doc)
         """
         pass
 

--- a/tests/retrievers/test_bge_m3_retriever.py
+++ b/tests/retrievers/test_bge_m3_retriever.py
@@ -8,18 +8,17 @@ def retriever():
 
 
 def test_forward_queries(retriever: BGEM3Retriever, queries_fixtures):
-    embeddings_queries = retriever.forward_queries(queries_fixtures)
-    assert embeddings_queries.shape == (len(queries_fixtures), retriever.emb_dim_query)
+    embeddings_queries = retriever.forward_queries(queries_fixtures, batch_size=1)
+    assert len(embeddings_queries) == len(queries_fixtures)
 
 
 def test_forward_documents(retriever: BGEM3Retriever, document_ocr_text_fixture):
-    embeddings_docs = retriever.forward_documents(document_ocr_text_fixture)
-    assert embeddings_docs.shape == (len(document_ocr_text_fixture), retriever.emb_dim_doc)
+    embeddings_docs = retriever.forward_documents(document_ocr_text_fixture, batch_size=1)
+    assert len(embeddings_docs) == len(document_ocr_text_fixture)
 
 
 def test_get_scores(retriever: BGEM3Retriever, queries_fixtures, document_ocr_text_fixture):
-    emb_query, emb_doc = retriever.get_embeddings(
-        queries_fixtures, document_ocr_text_fixture, batch_query=1, batch_doc=1
-    )
+    emb_query = retriever.forward_queries(queries_fixtures, batch_size=1)
+    emb_doc = retriever.forward_documents(document_ocr_text_fixture, batch_size=1)
     scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_ocr_text_fixture))

--- a/tests/retrievers/test_bge_m3_retriever.py
+++ b/tests/retrievers/test_bge_m3_retriever.py
@@ -18,5 +18,8 @@ def test_forward_documents(retriever: BGEM3Retriever, document_ocr_text_fixture)
 
 
 def test_get_scores(retriever: BGEM3Retriever, queries_fixtures, document_ocr_text_fixture):
-    scores = retriever.get_scores(queries_fixtures, document_ocr_text_fixture, batch_query=1, batch_doc=1)
+    emb_query, emb_doc = retriever.get_embeddings(
+        queries_fixtures, document_ocr_text_fixture, batch_query=1, batch_doc=1
+    )
+    scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_ocr_text_fixture))

--- a/tests/retrievers/test_bm25_retriever.py
+++ b/tests/retrievers/test_bm25_retriever.py
@@ -18,5 +18,5 @@ def test_forward_documents(retriever: BM25Retriever, document_ocr_text_fixture):
 
 
 def test_get_scores(retriever: BM25Retriever, queries_fixtures, document_ocr_text_fixture):
-    scores = retriever.get_scores(queries_fixtures, document_ocr_text_fixture, batch_query=1, batch_doc=1)
+    scores = retriever.get_scores_bm25(queries_fixtures, document_ocr_text_fixture, batch_query=1, batch_doc=1)
     assert scores.shape == (len(queries_fixtures), len(document_ocr_text_fixture))

--- a/tests/retrievers/test_colpali_retriever.py
+++ b/tests/retrievers/test_colpali_retriever.py
@@ -20,5 +20,6 @@ def test_forward_documents(retriever: ColPaliRetriever, document_images_fixture)
 
 
 def test_get_scores(retriever: ColPaliRetriever, queries_fixtures, document_images_fixture):
-    scores = retriever.get_scores(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    emb_query, emb_doc = retriever.get_embeddings(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_images_fixture))

--- a/tests/retrievers/test_colpali_retriever.py
+++ b/tests/retrievers/test_colpali_retriever.py
@@ -8,18 +8,19 @@ def retriever():
 
 
 def test_forward_queries(retriever: ColPaliRetriever, queries_fixtures):
-    embedding_queries = retriever.forward_queries(queries_fixtures)
+    embedding_queries = retriever.forward_queries(queries_fixtures, batch_size=1)
     assert len(embedding_queries) == len(queries_fixtures)
     assert embedding_queries[0].shape[1] == 128
 
 
 def test_forward_documents(retriever: ColPaliRetriever, document_images_fixture):
-    embedding_docs = retriever.forward_documents(document_images_fixture)
+    embedding_docs = retriever.forward_documents(document_images_fixture, batch_size=1)
     assert len(embedding_docs) == len(document_images_fixture)
     assert embedding_docs[0].shape[1] == 128
 
 
 def test_get_scores(retriever: ColPaliRetriever, queries_fixtures, document_images_fixture):
-    emb_query, emb_doc = retriever.get_embeddings(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    emb_query = retriever.forward_queries(queries_fixtures, batch_size=1)
+    emb_doc = retriever.forward_documents(document_images_fixture, batch_size=1)
     scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_images_fixture))

--- a/tests/retrievers/test_dummy_retriever.py
+++ b/tests/retrievers/test_dummy_retriever.py
@@ -18,5 +18,8 @@ def test_forward_documents(dummy_retriever: DummyRetriever, document_filepaths_f
 
 
 def test_get_scores(dummy_retriever: DummyRetriever, queries_fixtures, document_filepaths_fixture):
-    scores = dummy_retriever.get_scores(queries_fixtures, document_filepaths_fixture, batch_query=1, batch_doc=1)
+    emb_query, emb_doc = dummy_retriever.get_embeddings(
+        queries_fixtures, document_filepaths_fixture, batch_query=1, batch_doc=1
+    )
+    scores = dummy_retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_filepaths_fixture))

--- a/tests/retrievers/test_dummy_retriever.py
+++ b/tests/retrievers/test_dummy_retriever.py
@@ -8,18 +8,16 @@ def dummy_retriever():
 
 
 def test_forward_queries(dummy_retriever: DummyRetriever, queries_fixtures):
-    embeddings_queries = dummy_retriever.forward_queries(queries_fixtures)
-    assert embeddings_queries.shape == (len(queries_fixtures), dummy_retriever.emb_dim_query)
-
+    embeddings_queries = dummy_retriever.forward_queries(queries_fixtures, batch_size=1)
+    assert len(embeddings_queries) == len(queries_fixtures)
 
 def test_forward_documents(dummy_retriever: DummyRetriever, document_filepaths_fixture):
-    embeddings_docs = dummy_retriever.forward_documents(document_filepaths_fixture)
-    assert embeddings_docs.shape == (len(document_filepaths_fixture), dummy_retriever.emb_dim_doc)
+    embeddings_docs = dummy_retriever.forward_documents(document_filepaths_fixture, batch_size=1)
+    assert len(embeddings_docs) == len(document_filepaths_fixture)
 
 
 def test_get_scores(dummy_retriever: DummyRetriever, queries_fixtures, document_filepaths_fixture):
-    emb_query, emb_doc = dummy_retriever.get_embeddings(
-        queries_fixtures, document_filepaths_fixture, batch_query=1, batch_doc=1
-    )
+    emb_query = dummy_retriever.forward_queries(queries_fixtures, batch_size=1)
+    emb_doc = dummy_retriever.forward_documents(document_filepaths_fixture, batch_size=1)
     scores = dummy_retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_filepaths_fixture))

--- a/tests/retrievers/test_jina_clip_retriever.py
+++ b/tests/retrievers/test_jina_clip_retriever.py
@@ -8,16 +8,17 @@ def retriever():
 
 
 def test_forward_queries(retriever: JinaClipRetriever, queries_fixtures):
-    embeddings_queries = retriever.forward_queries(queries_fixtures)
-    assert embeddings_queries.shape == (len(queries_fixtures), retriever.emb_dim_query)
+    embeddings_queries = retriever.forward_queries(queries_fixtures, batch_size=1)
+    assert len(embeddings_queries) == len(queries_fixtures)
 
 
 def test_forward_documents(retriever: JinaClipRetriever, document_images_fixture):
-    embeddings_docs = retriever.forward_documents(document_images_fixture)
-    assert embeddings_docs.shape == (len(document_images_fixture), retriever.emb_dim_doc)
+    embeddings_docs = retriever.forward_documents(document_images_fixture, batch_size=1)
+    assert len(embeddings_docs) == len(document_images_fixture)
 
 
 def test_get_scores(retriever: JinaClipRetriever, queries_fixtures, document_images_fixture):
-    emb_query, emb_doc = retriever.get_embeddings(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    emb_query = retriever.forward_queries(queries_fixtures, batch_size=1)
+    emb_doc = retriever.forward_documents(document_images_fixture, batch_size=1)
     scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_images_fixture))

--- a/tests/retrievers/test_jina_clip_retriever.py
+++ b/tests/retrievers/test_jina_clip_retriever.py
@@ -18,5 +18,6 @@ def test_forward_documents(retriever: JinaClipRetriever, document_images_fixture
 
 
 def test_get_scores(retriever: JinaClipRetriever, queries_fixtures, document_images_fixture):
-    scores = retriever.get_scores(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    emb_query, emb_doc = retriever.get_embeddings(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_images_fixture))

--- a/tests/retrievers/test_nomic_retriever.py
+++ b/tests/retrievers/test_nomic_retriever.py
@@ -8,16 +8,17 @@ def retriever():
 
 
 def test_forward_queries(retriever: NomicVisionRetriever, queries_fixtures):
-    embeddings_queries = retriever.forward_queries(queries_fixtures)
-    assert embeddings_queries.shape == (len(queries_fixtures), retriever.emb_dim_query)
+    embeddings_queries = retriever.forward_queries(queries_fixtures, batch_size=1)
+    assert len(embeddings_queries) == len(queries_fixtures)
 
 
 def test_forward_documents(retriever: NomicVisionRetriever, document_images_fixture):
-    embeddings_docs = retriever.forward_documents(document_images_fixture)
-    assert embeddings_docs.shape == (len(document_images_fixture), retriever.emb_dim_doc)
+    embeddings_docs = retriever.forward_documents(document_images_fixture, batch_size=1)
+    assert len(embeddings_docs) == len(document_images_fixture)
 
 
 def test_get_scores(retriever: NomicVisionRetriever, queries_fixtures, document_images_fixture):
-    emb_query, emb_doc = retriever.get_embeddings(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    emb_query = retriever.forward_queries(queries_fixtures, batch_size=1)
+    emb_doc = retriever.forward_documents(document_images_fixture, batch_size=1)
     scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_images_fixture))

--- a/tests/retrievers/test_nomic_retriever.py
+++ b/tests/retrievers/test_nomic_retriever.py
@@ -18,5 +18,6 @@ def test_forward_documents(retriever: NomicVisionRetriever, document_images_fixt
 
 
 def test_get_scores(retriever: NomicVisionRetriever, queries_fixtures, document_images_fixture):
-    scores = retriever.get_scores(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    emb_query, emb_doc = retriever.get_embeddings(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_images_fixture))

--- a/tests/retrievers/test_siglip_retriever.py
+++ b/tests/retrievers/test_siglip_retriever.py
@@ -8,18 +8,17 @@ def retriever():
 
 
 def test_forward_queries(retriever: SigLIPRetriever, queries_fixtures):
-    embedding_queries = retriever.forward_queries(queries_fixtures)
+    embedding_queries = retriever.forward_queries(queries_fixtures, batch_size=1)
     assert len(embedding_queries) == len(queries_fixtures)
-    assert embedding_queries.shape == (len(queries_fixtures), 1152)
 
 
 def test_forward_documents(retriever: SigLIPRetriever, document_images_fixture):
-    embedding_docs = retriever.forward_documents(document_images_fixture)
+    embedding_docs = retriever.forward_documents(document_images_fixture, batch_size=1)
     assert len(embedding_docs) == len(document_images_fixture)
-    assert embedding_docs.shape == (len(document_images_fixture), 1152)
 
 
 def test_get_scores(retriever: SigLIPRetriever, queries_fixtures, document_images_fixture):
-    emb_query, emb_doc = retriever.get_embeddings(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    emb_query = retriever.forward_queries(queries_fixtures, batch_size=1)
+    emb_doc = retriever.forward_documents(document_images_fixture, batch_size=1)
     scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_images_fixture))

--- a/tests/retrievers/test_siglip_retriever.py
+++ b/tests/retrievers/test_siglip_retriever.py
@@ -20,5 +20,6 @@ def test_forward_documents(retriever: SigLIPRetriever, document_images_fixture):
 
 
 def test_get_scores(retriever: SigLIPRetriever, queries_fixtures, document_images_fixture):
-    scores = retriever.get_scores(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    emb_query, emb_doc = retriever.get_embeddings(queries_fixtures, document_images_fixture, batch_query=1, batch_doc=1)
+    scores = retriever.get_scores(emb_query, emb_doc)
     assert scores.shape == (len(queries_fixtures), len(document_images_fixture))


### PR DESCRIPTION
## Features

- [Breaking] `forward_queries` and `forward_documents` now require a `batch_size` argument